### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   code-style:
     uses: ./.github/workflows/code-style.yml


### PR DESCRIPTION
Potential fix for [https://github.com/LiquidCats/rater/security/code-scanning/5](https://github.com/LiquidCats/rater/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `packages: write` for interacting with the GitHub Container Registry.

The `permissions` block should be added at the root level of the workflow to apply to all jobs unless overridden by individual job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
