### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LiquidCats/rater/security/code-scanning/2](https://github.com/LiquidCats/rater/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks out code and runs a linting tool, it requires minimal permissions. The `contents: read` permission is sufficient for these operations. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
