### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Go Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/LiquidCats/rater/security/code-scanning/1](https://github.com/LiquidCats/rater/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow only checks out the repository and runs tests, it only needs `contents: read` permission. The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `test` job to limit permissions specifically for that job.

The best approach is to add the `permissions` block at the root level of the workflow, as this ensures consistency and avoids redundancy if additional jobs are added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
