### PR TITLE
Update rate endpoints to use query parameters for dates

### DIFF
--- a/cmd/rater/main.go
+++ b/cmd/rater/main.go
@@ -108,7 +108,7 @@ func main() { //nolint:funlen
 	v1Router := router.Group("/v1")
 	v1Router.GET("/", rootHandler.Handle)
 	v1Router.GET(
-		"/rate/:pair/*date",
+		"/rate/:pair",
 		pairValidationMiddleware.Handle,
 		dateValidationMiddleware.Handle,
 		rateHandler.Handle,

--- a/internal/adapter/http/middlware/date_validation.go
+++ b/internal/adapter/http/middlware/date_validation.go
@@ -19,7 +19,7 @@ func NewDateValidation() *DateValidationMiddleware {
 }
 
 func (m *DateValidationMiddleware) Handle(ctx *gin.Context) {
-	date := strings.TrimSpace(strings.TrimPrefix(ctx.Param("date"), "/"))
+	date := strings.TrimSpace(ctx.Query("date"))
 	if date == "" {
 		ctx.Next()
 		return

--- a/internal/adapter/http/middlware/date_validation_test.go
+++ b/internal/adapter/http/middlware/date_validation_test.go
@@ -64,14 +64,14 @@ func TestDateValidationMiddleware_Handle(t *testing.T) {
 			dateValidationMiddleware := middlware.NewDateValidation()
 			// Add middleware and a test handler
 			handlerCalled := false
-			router.GET("/test/*date", dateValidationMiddleware.Handle, func(c *gin.Context) {
+			router.GET("/test", dateValidationMiddleware.Handle, func(c *gin.Context) {
 				handlerCalled = true
 				c.Status(http.StatusOK)
 			})
 
 			// Create request
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, "/test/"+tt.dateParam, nil)
+			req := httptest.NewRequest(http.MethodGet, "/test?date="+tt.dateParam, nil)
 
 			// Execute
 			router.ServeHTTP(w, req)
@@ -117,7 +117,7 @@ func TestDateValidationMiddleware_Handle_FutureDateTime(t *testing.T) {
 
 	handlerCalled := false
 	router.Use(middlware.NewDateValidation().Handle)
-	router.GET("/test/:date", func(c *gin.Context) {
+	router.GET("/test", func(c *gin.Context) {
 		handlerCalled = true
 		c.Status(http.StatusOK)
 	})
@@ -126,7 +126,7 @@ func TestDateValidationMiddleware_Handle_FutureDateTime(t *testing.T) {
 	futureDate := time.Now().Add(24 * time.Hour).Format(entity.DefaultFormat)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/test/"+futureDate, nil)
+	req := httptest.NewRequest(http.MethodGet, "/test?date="+futureDate, nil)
 	router.ServeHTTP(w, req)
 
 	assert.False(t, handlerCalled, "Handler should not be called for future dates")
@@ -164,14 +164,14 @@ func TestDateValidationMiddleware_Handle_ParseError(t *testing.T) {
 
 	handlerCalled := false
 	router.Use(middlware.NewDateValidation().Handle)
-	router.GET("/test/:date", func(c *gin.Context) {
+	router.GET("/test", func(c *gin.Context) {
 		handlerCalled = true
 		c.Status(http.StatusOK)
 	})
 
 	invalidDate := "not-a-date"
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/test/"+invalidDate, nil)
+	req := httptest.NewRequest(http.MethodGet, "/test?date="+invalidDate, nil)
 	router.ServeHTTP(w, req)
 
 	assert.False(t, handlerCalled, "Handler should not be called for invalid dates")
@@ -208,13 +208,13 @@ func TestDateValidationMiddleware_ResponseStructure(t *testing.T) {
 	router := gin.New()
 
 	router.Use(middlware.NewDateValidation().Handle)
-	router.GET("/test/:date", func(c *gin.Context) {
+	router.GET("/test", func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
 
 	// Test with invalid date to trigger validation error
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/test/invalid-date", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test?date=invalid-date", nil)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)

--- a/internal/adapter/http/routes/rate.go
+++ b/internal/adapter/http/routes/rate.go
@@ -38,7 +38,7 @@ func (r *RateHandler) Handle(ctx *gin.Context) {
 	symbol := entity.Symbol(ctx.Param("pair"))
 
 	date := time.Now()
-	if d := strings.TrimPrefix(ctx.Param("date"), "/"); d != "" {
+	if d := strings.TrimSpace(ctx.Query("date")); d != "" {
 		date, _ = time.Parse(entity.DefaultFormat, d)
 	}
 

--- a/internal/adapter/http/routes/rate_test.go
+++ b/internal/adapter/http/routes/rate_test.go
@@ -102,11 +102,9 @@ func TestRateHandler_Handle(t *testing.T) {
 					Provider: "test",
 				}
 
-				dt := time.Date(2021, 4, 15, 11, 42, 31, 0, time.UTC).
-					Format(entity.DefaultFormat)
 				ts := time.Date(2021, 4, 15, 11, 40, 0, 0, time.UTC)
 				service.On("Historical", mock.Anything, rate.Pair, ts).Once().Return(&rate, nil)
-				m.On("Observe", "/rate/BTC_USD/"+dt, mock.Anything).Once().Return()
+				m.On("Observe", "/rate/BTC_USD", mock.Anything).Once().Return()
 
 				uc := usecase.NewRateUseCase(usecase.RateUseCaseDeps{
 					Cache:   cache,
@@ -127,15 +125,14 @@ func TestRateHandler_Handle(t *testing.T) {
 			})
 
 			router := http2.NewRouter()
+			router.GET("/rate/:pair", handler.Handle)
 
 			w := httptest.NewRecorder()
 			var req *http.Request
 			if test.ts.IsZero() {
-				router.GET("/rate/:pair", handler.Handle)
-				req, _ = http.NewRequest(http.MethodGet, fmt.Sprint("/rate/", "BTC_USD"), nil)
+				req, _ = http.NewRequest(http.MethodGet, "/rate/BTC_USD", nil)
 			} else {
-				router.GET("/rate/:pair/*date", handler.Handle)
-				req, _ = http.NewRequest(http.MethodGet, fmt.Sprint("/rate/BTC_USD/", test.ts.Format(entity.DefaultFormat)), nil)
+				req, _ = http.NewRequest(http.MethodGet, fmt.Sprint("/rate/BTC_USD?date=", test.ts.Format(entity.DefaultFormat)), nil)
 			}
 
 			router.ServeHTTP(w, req)


### PR DESCRIPTION
The refactor modifies the rate endpoints to handle date values through query parameters instead of path segments. This change enhances flexibility and aligns with best practices for API design. No functional differences are introduced.